### PR TITLE
Add support for resource quotas

### DIFF
--- a/scripts/google_analytics/update_counts.py
+++ b/scripts/google_analytics/update_counts.py
@@ -67,6 +67,7 @@ def get_count_report(analytics, view_id, event_name):
                               "expressions": event_name
                             }
                             ]}],
+                    "useResourceQuotas": true
                 }
             ]
         }

--- a/scripts/google_analytics/update_data.py
+++ b/scripts/google_analytics/update_data.py
@@ -76,6 +76,7 @@ def get_reports(analytics, view_id, page_filter):
                               "expressions": page_filter
                             }
                             ]}],
+                    "useResourceQuotas": true
                 },
                 {
                     'viewId': view_id,
@@ -84,7 +85,7 @@ def get_reports(analytics, view_id, page_filter):
                     'metrics': [{'expression': 'ga:sessions'}],
                     'dimensions': [{'name': 'ga:isoYearIsoWeek'},
                                    {'name': 'ga:deviceCategory'}],
-                   "dimensionFilterClauses": [{
+                    "dimensionFilterClauses": [{
                        "filters": [
                            {
                              "dimensionName": "ga:pagePath",
@@ -92,6 +93,7 @@ def get_reports(analytics, view_id, page_filter):
                              "expressions": page_filter
                            }
                            ]}],
+                    "useResourceQuotas": true
                 },
                 {
                     'viewId': view_id,
@@ -99,7 +101,7 @@ def get_reports(analytics, view_id, page_filter):
                                     'endDate': endDate}],
                     'metrics': [{'expression': 'ga:pageviews'}],
                     'dimensions': [{'name': 'ga:isoYearIsoWeek'}],
-                   "dimensionFilterClauses": [{
+                    "dimensionFilterClauses": [{
                        "filters": [
                            {
                              "dimensionName": "ga:pagePath",
@@ -107,6 +109,7 @@ def get_reports(analytics, view_id, page_filter):
                              "expressions": page_filter
                            }
                            ]}],
+                    "useResourceQuotas": true
                 }
                 ]
         }
@@ -163,6 +166,7 @@ def get_click_reports(analytics, view_id):
                             },
                             ]}],
                     "includeEmptyRows": "true",
+                    "useResourceQuotas": true
                 }
                 ]
         }


### PR DESCRIPTION
Closes: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6071

Implements technique from https://developers.google.com/analytics/devguides/reporting/core/v4/resource-based-quota

Our project was approved for inclusion in the beta.  This will help us avoid any sampling of the reports used to generate the scorecard data.