### PR TITLE
Using the Docker image for Python 3.6 

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 WORKDIR /application
 


### PR DESCRIPTION
Needed for compatibility with ruamel-yaml v0.14.12