### PR TITLE
[Saman/Shifali] move   X-UA-Compatible meta tag as the first tag so IE11 displays the graphs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@ title: VA.gov Performance
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <!-- Google Tag Manager -->
   <script nonce="**CSP_NONCE**">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -21,7 +22,6 @@ title: VA.gov Performance
   <title>{{page.title}}</title>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
   <link rel="shortcut icon" href="assets/img/favicon.ico" />
 


### PR DESCRIPTION
The graphs in IE11 on GFE were not displayed.  This will fix the issue.