### PR TITLE
[#3195][Saman/Shefali] add robots meta tag to avoid search engines indexing

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@ title: VA.gov Performance
 <html lang="en">
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="robots" content="noindex" />
   <!-- Google Tag Manager -->
   <script nonce="**CSP_NONCE**">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
If a search crawler gots to the performance-dashboard page, then the robots meta tag indicates no indexing 