### PR TITLE
at_a_glance.html: Add CSP_NONCE to charts script

### DIFF
--- a/src/_includes/at_a_glance.html
+++ b/src/_includes/at_a_glance.html
@@ -68,7 +68,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="**CSP_NONCE**">
     {% include charts/chart_nav.js %}
 </script>
 


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/14936

## Description

The `charts/chart_nav.js` script on the [`/performance-dashboard` page](https://staging.va.gov/performance-dashboard/) is being blocked by the Content Security Policy. 

## Screenshot

![image](https://user-images.githubusercontent.com/6130520/96186333-e6b57380-0f00-11eb-8fca-3b3b78ed1352.png)
