### PR TITLE
Add nonce=CSP_NONCE to scripts

### DIFF
--- a/src/_includes/at_a_glance.html
+++ b/src/_includes/at_a_glance.html
@@ -68,7 +68,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="**CSP_NONCE**">
     {% include charts/chart_nav.js %}
 </script>
 

--- a/src/index.html
+++ b/src/index.html
@@ -26,9 +26,9 @@ title: VA.gov Performance
 
   <link rel="shortcut icon" href="assets/img/favicon.ico" />
 
-  <script src="assets/vendor/chart.js/Chart.bundle.min.js"></script>
-  <script src="assets/js/array_from_polyfill.js"></script>
-  <script src="assets/vendor/formation/formation.js"></script>
+  <script nonce="**CSP_NONCE**" src="assets/vendor/chart.js/Chart.bundle.min.js"></script>
+  <script nonce="**CSP_NONCE**" src="assets/js/array_from_polyfill.js"></script>
+  <script nonce="**CSP_NONCE**" src="assets/vendor/formation/formation.js"></script>
 
   <link rel="stylesheet" type="text/css" href="assets/vendor/formation/formation.min.css" />
   <link rel="stylesheet" type="text/css" href="assets/stylesheets/main.css" />


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/14936

## Description

This PR adds `nonce="**CSP_NONCE**"` to several scripts on the [`/performance-dashboard` page](https://staging.va.gov/performance-dashboard/) so that those scripts stop getting blocked by the content security policy

- [The `assets/vendor/chart.js/Chart.bundle.min.js` script](https://github.com/department-of-veterans-affairs/vets.gov-status/blob/1ba00af6e7b8550007eb3de97d12367df7d993eb/src/index.html#L29)
- [The `assets/js/array_from_polyfill.js` script](https://github.com/department-of-veterans-affairs/vets.gov-status/blob/1ba00af6e7b8550007eb3de97d12367df7d993eb/src/index.html#L30)
- [The `assets/vendor/formation/formation.js` script](https://github.com/department-of-veterans-affairs/vets.gov-status/blob/1ba00af6e7b8550007eb3de97d12367df7d993eb/src/index.html#L31)
- [The `charts/chart_nav.js` script](https://github.com/department-of-veterans-affairs/vets.gov-status/blob/1ba00af6e7b8550007eb3de97d12367df7d993eb/src/_includes/at_a_glance.html#L71)

## Screenshot

![image](https://user-images.githubusercontent.com/6130520/96186333-e6b57380-0f00-11eb-8fca-3b3b78ed1352.png)

## Relevant Links

- `#vsp-tools-fe` [thread](https://dsva.slack.com/archives/CQH357ZTP/p1602771949155900)
- `#platform-team` [thread](https://dsva.slack.com/archives/CJRQ85PQB/p1602773929257900)