### PR TITLE
Changes time to start at 9am UTC

### DIFF
--- a/.github/workflows/trigger-data-update.yml
+++ b/.github/workflows/trigger-data-update.yml
@@ -2,7 +2,8 @@ name: "Daily Data Refresh Trigger"
 
 on:
   schedule:
-    - cron: '5 3 * * *'
+    # 9:05am UTC, which is 01:05 or 02:05am Pacific, so we trigger the job just after the Google analytics quota resets
+    - cron: '5 9 * * *'
 
 jobs:
   trigger-data-refresh:


### PR DESCRIPTION
Because Google analytics rate limits expire at midnight, we trigger our job to run at 1am or 2am pacific time, to limit the chances that the job doesn't get rate limited.